### PR TITLE
fixing main in package.json to point to dist/js/angular-flippy.min.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-flippy",
   "version": "2.0.3",
   "description": "AngularJS directive implementation with a CSS3 flip animation.",
-  "main": "dist/angular-flippy.min.js",
+  "main": "dist/js/angular-flippy.min.js",
   "scripts": {},
   "repository": {
     "type": "git",


### PR DESCRIPTION
Browserify was unable to build/inject due to incorrect path in package.json main section
